### PR TITLE
[OPP-1490] Skifte pub fra docker til ghcr.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build, push, and deploy
 on: [push]
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/modiapersonoversikt-draft:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/modiapersonoversikt-draft:${{ github.sha }}
   CI: true
   TZ: Europe/Oslo
 jobs:
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker build --tag ${IMAGE} .
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
           docker push ${IMAGE}
   deploy-qa:
     name: Deploy to preprod


### PR DESCRIPTION
docker.pkg.github.com er deprecated, erstattet med ghcr.io