### PR TITLE
[KAIZEN-0] legge til muligheten for å oppdatere/slette drafts via websockets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation("io.ktor:ktor-server-cors:$ktorVersion")
     implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
     implementation("io.ktor:ktor-server-forwarded-header:$ktorVersion")
+    implementation("io.ktor:ktor-server-websockets:$ktorVersion")
 
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")

--- a/src/main/kotlin/no/nav/modiapersonoversikt/Application.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/Application.kt
@@ -17,6 +17,7 @@ import no.nav.modiapersonoversikt.config.Configuration
 import no.nav.modiapersonoversikt.draft.DraftDAOImpl
 import no.nav.modiapersonoversikt.draft.UuidDAOImpl
 import no.nav.modiapersonoversikt.draft.draftRoutes
+import no.nav.modiapersonoversikt.infrastructure.UUIDPrincipal
 import no.nav.modiapersonoversikt.infrastructure.exceptionHandler
 import no.nav.modiapersonoversikt.infrastructure.notFoundHandler
 import no.nav.modiapersonoversikt.utils.JacksonUtils.objectMapper
@@ -73,9 +74,10 @@ fun Application.draftApp(
         }
         basic("ws") {
             validate {
-                val uuid = UUID.fromString(it.name)
-                val user = uuidDAO.getOwner(uuid)
-                user?.let(::UserIdPrincipal)
+                UUIDPrincipal(UUID.fromString(it.name))
+//                val uuid = UUID.fromString(it.name)
+//                val user = uuidDAO.getOwner(uuid)
+//                user?.let(::UserIdPrincipal)
             }
         }
     }

--- a/src/main/kotlin/no/nav/modiapersonoversikt/Application.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/Application.kt
@@ -11,16 +11,20 @@ import io.ktor.server.plugins.forwardedheaders.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
+import io.ktor.server.websocket.*
 import kotlinx.coroutines.runBlocking
 import no.nav.modiapersonoversikt.config.Configuration
 import no.nav.modiapersonoversikt.draft.DraftDAOImpl
+import no.nav.modiapersonoversikt.draft.UuidDAOImpl
 import no.nav.modiapersonoversikt.draft.draftRoutes
 import no.nav.modiapersonoversikt.infrastructure.exceptionHandler
 import no.nav.modiapersonoversikt.infrastructure.notFoundHandler
 import no.nav.modiapersonoversikt.utils.JacksonUtils.objectMapper
 import no.nav.personoversikt.ktor.utils.Metrics
+import no.nav.personoversikt.ktor.utils.Security
 import no.nav.personoversikt.ktor.utils.Selftest
 import org.slf4j.event.Level
+import java.util.*
 import javax.sql.DataSource
 import kotlin.concurrent.fixedRateTimer
 import kotlin.time.Duration.Companion.minutes
@@ -30,10 +34,14 @@ fun Application.draftApp(
     dataSource: DataSource,
     useMock: Boolean = false
 ) {
-    val security = no.nav.personoversikt.ktor.utils.Security(listOfNotNull(
-        configuration.openam,
-        configuration.azuread,
-    ))
+    val security = Security(
+        listOfNotNull(
+            configuration.openam,
+            configuration.azuread,
+        )
+    )
+    val draftDAO = DraftDAOImpl(dataSource)
+    val uuidDAO = UuidDAOImpl(dataSource)
 
     install(XForwardedHeaders)
     install(StatusPages) {
@@ -57,17 +65,27 @@ fun Application.draftApp(
         version = appImage
     }
 
-
     install(Authentication) {
         if (useMock) {
             security.setupMock(this, "Z999999")
         } else {
             security.setupJWT(this)
         }
+        basic("ws") {
+            validate {
+                val uuid = UUID.fromString(it.name)
+                val user = uuidDAO.getOwner(uuid)
+                user?.let(::UserIdPrincipal)
+            }
+        }
     }
 
     install(ContentNegotiation) {
         register(ContentType.Application.Json, JacksonConverter(objectMapper))
+    }
+
+    install(WebSockets) {
+        contentConverter = JacksonWebsocketContentConverter(objectMapper)
     }
 
     install(CallLogging) {
@@ -77,8 +95,6 @@ fun Application.draftApp(
         mdc("userId") { call -> security.getSubject(call).joinToString(";") }
     }
 
-    val draftDAO = DraftDAOImpl(dataSource)
-
     fixedRateTimer(
         daemon = true,
         initialDelay = 5.minutes.inWholeMilliseconds,
@@ -86,13 +102,14 @@ fun Application.draftApp(
     ) {
         runBlocking {
             draftDAO.deleteOldDrafts()
+            uuidDAO.deleteExpired()
         }
     }
 
     routing {
         route(appContextpath) {
             route("api") {
-                draftRoutes(security.authproviders, draftDAO)
+                draftRoutes(security.authproviders, draftDAO, uuidDAO)
             }
         }
     }

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftRoutes.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftRoutes.kt
@@ -53,7 +53,7 @@ fun Route.draftRoutes(authProviders: Array<String?>, dao: DraftDAO, uuidDAO: Uui
     authenticate(*authProviders) {
         get("/generate-uid") {
             withSubject { subject ->
-                call.respond(uuidDAO.generateUid(subject).toString())
+                call.respond(uuidDAO.generateUid(subject).uuid.toString())
             }
         }
     }

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftRoutes.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftRoutes.kt
@@ -1,20 +1,24 @@
 package no.nav.modiapersonoversikt.draft
 
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.Parameters
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
-import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.principal
-import io.ktor.server.request.receive
-import io.ktor.server.response.respond
+import io.ktor.http.*
+import io.ktor.serialization.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.util.filter
-import io.ktor.util.pipeline.PipelineContext
-import io.ktor.util.toMap
+import io.ktor.server.websocket.*
+import io.ktor.util.*
+import io.ktor.util.pipeline.*
+import io.ktor.util.reflect.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import no.nav.modiapersonoversikt.log
 import no.nav.personoversikt.ktor.utils.Security.SubjectPrincipal
 
-fun Route.draftRoutes(authProviders: Array<String?>, dao: DraftDAO) {
+fun Route.draftRoutes(authProviders: Array<String?>, dao: DraftDAO, uuidDAO: UuidDAO) {
+    val wsHandler = WsHandler(dao)
+
     authenticate(*authProviders) {
         route("/draft") {
             get {
@@ -43,6 +47,44 @@ fun Route.draftRoutes(authProviders: Array<String?>, dao: DraftDAO) {
             }
         }
     }
+
+    authenticate(*authProviders) {
+        get("/generate-uid") {
+            withSubject { subject ->
+                call.respond(uuidDAO.generateUid(subject).toString())
+            }
+        }
+    }
+    authenticate("ws") {
+        webSocket("/draft/ws") {
+            val owner = checkNotNull(this.call.principal<UserIdPrincipal>()).name
+            println("connected")
+            try {
+                while (true) {
+                    wsHandler.process(owner, receiveDeserialized())
+                }
+            } catch (e: ClosedReceiveChannelException) {
+                // This is expected when client disconnectes
+            } catch (e: Throwable) {
+                log.error("Error in WS", e)
+            }
+        }
+    }
+}
+
+suspend inline fun <reified T> WebSocketServerSession.deserialize(frame: Frame.Text): T {
+    val conv = checkNotNull(converter) { "No converter found" }
+    val result = conv.deserialize(
+        charset = call.request.headers.suitableCharset(),
+        typeInfo = typeInfo<T>(),
+        content = frame
+    )
+    if (result is T) return result
+
+    throw WebsocketDeserializeException(
+        "Can't deserialize value : expected value of type ${T::class.simpleName}, got ${result::class.simpleName}",
+        frame = frame
+    )
 }
 
 private fun Parameters.parse(): Pair<Boolean, DraftContext> {

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAO.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAO.kt
@@ -1,0 +1,18 @@
+package no.nav.modiapersonoversikt.draft
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface UuidDAO {
+    suspend fun generateUid(owner: String): UUID
+    suspend fun getOwner(uuid: UUID): String?
+    suspend fun deleteExpired(): Int
+
+    data class TableRow(
+        val owner: String,
+        val uuid: UUID,
+        val created: LocalDateTime
+    ) {
+        val shouldBeRefreshed = LocalDateTime.now().isAfter(created.plusHours(1))
+    }
+}

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAO.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAO.kt
@@ -4,11 +4,11 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 interface UuidDAO {
-    suspend fun generateUid(owner: String): UUID
-    suspend fun getOwner(uuid: UUID): String?
+    suspend fun generateUid(owner: String): OwnerUUID
+    suspend fun getOwner(uuid: UUID): OwnerUUID?
     suspend fun deleteExpired(): Int
 
-    data class TableRow(
+    data class OwnerUUID(
         val owner: String,
         val uuid: UUID,
         val created: LocalDateTime

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAOImpl.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAOImpl.kt
@@ -3,7 +3,7 @@ package no.nav.modiapersonoversikt.draft
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
-import no.nav.modiapersonoversikt.draft.UuidDAO.TableRow
+import no.nav.modiapersonoversikt.draft.UuidDAO.OwnerUUID
 import no.nav.modiapersonoversikt.log
 import no.nav.modiapersonoversikt.utils.execute
 import no.nav.modiapersonoversikt.utils.transactional
@@ -13,12 +13,12 @@ import javax.sql.DataSource
 private const val table = "owneruuid"
 
 class UuidDAOImpl(private val dataSource: DataSource) : UuidDAO {
-    override suspend fun generateUid(owner: String): UUID {
+    override suspend fun generateUid(owner: String): OwnerUUID {
         return transactional(dataSource) { tx -> generateUid(tx, owner) }
     }
 
-    override suspend fun getOwner(uuid: UUID): String? {
-        return transactional(dataSource) { tx -> getByUUID(tx, uuid)?.owner }
+    override suspend fun getOwner(uuid: UUID): OwnerUUID? {
+        return transactional(dataSource) { tx -> getByUUID(tx, uuid) }
     }
 
     override suspend fun deleteExpired(): Int {
@@ -31,47 +31,46 @@ class UuidDAOImpl(private val dataSource: DataSource) : UuidDAO {
     }
 }
 
-private fun generateUid(tx: TransactionalSession, owner: String): UUID {
+private fun generateUid(tx: TransactionalSession, owner: String): OwnerUUID {
     val existingUUID = getByOwner(tx, owner)
     return if (existingUUID == null) {
         val uuid = UUID.randomUUID()
         saveOwnerUUID(tx, owner, uuid)
-        uuid
     } else if (existingUUID.shouldBeRefreshed) {
-        val uuid = UUID.randomUUID()
         /**
          * Existing uuid will be removed by scheduled job (removed 4hour old uuid's).
          * But we're not removing it yet in case a browser-tab is open, and using it.
          */
+        val uuid = UUID.randomUUID()
         saveOwnerUUID(tx, owner, uuid)
-        uuid
     } else {
-        existingUUID.uuid
+        existingUUID
     }
 }
 
-private fun getByUUID(tx: TransactionalSession, uuid: UUID): TableRow? {
+private fun getByUUID(tx: TransactionalSession, uuid: UUID): OwnerUUID? {
     return queryOf("SELECT * FROM $table WHERE uuid = ?::uuid", uuid.toString())
         .map(rowMapper)
         .asSingle
         .execute(tx)
 }
 
-private fun getByOwner(tx: TransactionalSession, owner: String): TableRow? {
+private fun getByOwner(tx: TransactionalSession, owner: String): OwnerUUID? {
     return queryOf("SELECT * FROM $table WHERE owner = ? ORDER by created DESC", owner)
         .map(rowMapper)
         .asSingle
         .execute(tx)
 }
 
-private fun saveOwnerUUID(tx: TransactionalSession, owner: String, uuid: UUID) {
-    queryOf("INSERT INTO $table (owner, uuid) VALUES (?, ?)", owner, uuid)
-        .asUpdate
-        .execute(tx)
+private fun saveOwnerUUID(tx: TransactionalSession, owner: String, uuid: UUID): OwnerUUID {
+    return queryOf("INSERT INTO $table (owner, uuid) VALUES (?, ?) RETURNING owner, uuid, created", owner, uuid)
+        .map(rowMapper)
+        .asSingle
+        .execute(tx)!!
 }
 
-private val rowMapper: (Row) -> TableRow = { row ->
-    TableRow(
+val rowMapper: (Row) -> OwnerUUID = { row ->
+    OwnerUUID(
         owner = row.string("owner"),
         uuid = row.uuid("uuid"),
         created = row.localDateTime("created")

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAOImpl.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/UuidDAOImpl.kt
@@ -1,0 +1,79 @@
+package no.nav.modiapersonoversikt.draft
+
+import kotliquery.Row
+import kotliquery.TransactionalSession
+import kotliquery.queryOf
+import no.nav.modiapersonoversikt.draft.UuidDAO.TableRow
+import no.nav.modiapersonoversikt.log
+import no.nav.modiapersonoversikt.utils.execute
+import no.nav.modiapersonoversikt.utils.transactional
+import java.util.UUID
+import javax.sql.DataSource
+
+private const val table = "owneruuid"
+
+class UuidDAOImpl(private val dataSource: DataSource) : UuidDAO {
+    override suspend fun generateUid(owner: String): UUID {
+        return transactional(dataSource) { tx -> generateUid(tx, owner) }
+    }
+
+    override suspend fun getOwner(uuid: UUID): String? {
+        return transactional(dataSource) { tx -> getByUUID(tx, uuid)?.owner }
+    }
+
+    override suspend fun deleteExpired(): Int {
+        return transactional(dataSource) { tx ->
+            log.info("Deleting old uuid's")
+            tx
+                .run(queryOf("DELETE FROM $table WHERE created < now() - INTERVAL '4 HOUR'").asUpdate)
+                .also { log.info("Deleted old uuids: $it") }
+        }
+    }
+}
+
+private fun generateUid(tx: TransactionalSession, owner: String): UUID {
+    val existingUUID = getByOwner(tx, owner)
+    return if (existingUUID == null) {
+        val uuid = UUID.randomUUID()
+        saveOwnerUUID(tx, owner, uuid)
+        uuid
+    } else if (existingUUID.shouldBeRefreshed) {
+        val uuid = UUID.randomUUID()
+        /**
+         * Existing uuid will be removed by scheduled job (removed 4hour old uuid's).
+         * But we're not removing it yet in case a browser-tab is open, and using it.
+         */
+        saveOwnerUUID(tx, owner, uuid)
+        uuid
+    } else {
+        existingUUID.uuid
+    }
+}
+
+private fun getByUUID(tx: TransactionalSession, uuid: UUID): TableRow? {
+    return queryOf("SELECT * FROM $table WHERE uuid = ?::uuid", uuid.toString())
+        .map(rowMapper)
+        .asSingle
+        .execute(tx)
+}
+
+private fun getByOwner(tx: TransactionalSession, owner: String): TableRow? {
+    return queryOf("SELECT * FROM $table WHERE owner = ? ORDER by created DESC", owner)
+        .map(rowMapper)
+        .asSingle
+        .execute(tx)
+}
+
+private fun saveOwnerUUID(tx: TransactionalSession, owner: String, uuid: UUID) {
+    queryOf("INSERT INTO $table (owner, uuid) VALUES (?, ?)", owner, uuid)
+        .asUpdate
+        .execute(tx)
+}
+
+private val rowMapper: (Row) -> TableRow = { row ->
+    TableRow(
+        owner = row.string("owner"),
+        uuid = row.uuid("uuid"),
+        created = row.localDateTime("created")
+    )
+}

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/WsHandler.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/WsHandler.kt
@@ -1,0 +1,32 @@
+package no.nav.modiapersonoversikt.draft
+
+class WsHandler(val dao: DraftDAO) {
+    enum class EventType { UPDATE, DELETE; }
+    data class Message(
+        val type: EventType,
+        val context: DraftContext,
+        val content: String?
+    )
+
+    suspend fun process(owner: String, message: Message) {
+        when (message.type) {
+            EventType.UPDATE -> {
+                dao.save(
+                    SaveDraft(
+                        owner = owner,
+                        context = message.context,
+                        content = message.content ?: ""
+                    )
+                )
+            }
+            EventType.DELETE -> {
+                dao.delete(
+                    DraftIdentificator(
+                        owner = owner,
+                        context = message.context
+                    )
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/modiapersonoversikt/infrastructure/UUIDPrincipal.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/infrastructure/UUIDPrincipal.kt
@@ -1,0 +1,6 @@
+package no.nav.modiapersonoversikt.infrastructure
+
+import io.ktor.server.auth.*
+import java.util.*
+
+data class UUIDPrincipal(val uuid: UUID) : Principal

--- a/src/main/resources/db/migration/V1_2__uuid.sql
+++ b/src/main/resources/db/migration/V1_2__uuid.sql
@@ -1,0 +1,8 @@
+CREATE TABLE owneruuid(
+    owner       VARCHAR                     NOT NULL,
+    uuid        UUID        UNIQUE          NOT NULL,
+    created     TIMESTAMP   DEFAULT NOW()   NOT NULL
+);
+
+CREATE INDEX owneruuid_owner_idx ON owneruuid USING HASH(owner);
+CREATE INDEX owneruuid_uuid_idx ON owneruuid USING HASH(uuid);

--- a/src/test/kotlin/no/nav/modiapersonoversikt/TestUtils.kt
+++ b/src/test/kotlin/no/nav/modiapersonoversikt/TestUtils.kt
@@ -11,10 +11,10 @@ import no.nav.modiapersonoversikt.draft.Draft
 import no.nav.modiapersonoversikt.draft.DraftDTO
 import no.nav.modiapersonoversikt.draft.toDTO
 import no.nav.modiapersonoversikt.utils.transactional
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertAll
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -34,11 +34,12 @@ interface WithDatabase {
         }
     }
 
-    @BeforeEach
+    @AfterEach
     fun clearDatabase() {
         runBlocking {
             transactional(dbConfig.adminDataSource()) { tx ->
                 tx.run(queryOf("DELETE FROM draft").asExecute)
+                tx.run(queryOf("DELETE FROM owneruuid").asExecute)
             }
         }
     }

--- a/src/test/kotlin/no/nav/modiapersonoversikt/draft/UuidDAOTest.kt
+++ b/src/test/kotlin/no/nav/modiapersonoversikt/draft/UuidDAOTest.kt
@@ -1,0 +1,121 @@
+package no.nav.modiapersonoversikt.draft
+
+import kotlinx.coroutines.runBlocking
+import kotliquery.queryOf
+import no.nav.modiapersonoversikt.WithDatabase
+import no.nav.modiapersonoversikt.utils.transactional
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+internal class UuidDAOTest : WithDatabase {
+    val dao = UuidDAOImpl(dataSource())
+    val testuuid = UUID.randomUUID()
+
+    @BeforeEach
+    internal fun setUp() = runBlocking {
+        insert(
+            UuidDAO.TableRow(
+                owner = "Z999999",
+                uuid = testuuid,
+                created = LocalDateTime.now()
+            )
+        )
+    }
+
+    @Test
+    internal fun `should return null if no owner exists for uuid`() = runBlocking {
+        assertNull(dao.getOwner(UUID.randomUUID()))
+    }
+
+    @Test
+    internal fun `should return owner if uuid exists`() = runBlocking {
+        assertEquals("Z999999", dao.getOwner(testuuid))
+    }
+
+    @Test
+    internal fun `should generate new uuid if no uuid for owner exist`() = runBlocking {
+        val uuid = dao.generateUid("Z888888")
+        assertNotNull(uuid)
+        assertNotEquals(testuuid.toString(), uuid.toString())
+    }
+
+    @Test
+    internal fun `should generate new uuid if existing uuid is 1 hour old`() = runBlocking {
+        insert(
+            UuidDAO.TableRow(
+                owner = "Z888888",
+                uuid = testuuid,
+                created = LocalDateTime.now().minusHours(1)
+            )
+        )
+        val uuid = dao.generateUid("Z888888")
+        assertNotNull(uuid)
+        assertNotEquals(testuuid.toString(), uuid.toString())
+    }
+
+    @Test
+    internal fun `should return existing uuid if it is under 1 hour old`() = runBlocking {
+        insert(
+            UuidDAO.TableRow(
+                owner = "Z888888",
+                uuid = testuuid,
+                created = LocalDateTime.now().minusMinutes(58)
+            )
+        )
+        val uuid = dao.generateUid("Z888888")
+        assertNotNull(uuid)
+        assertEquals(testuuid.toString(), uuid.toString())
+    }
+
+    @Test
+    internal fun `should return newest existing uuid if it is under 1 hour old`() = runBlocking {
+        insert(
+            UuidDAO.TableRow(
+                owner = "Z888888",
+                uuid = UUID.randomUUID(),
+                created = LocalDateTime.now().minusMinutes(40)
+            )
+        )
+        insert(
+            UuidDAO.TableRow(
+                owner = "Z888888",
+                uuid = testuuid,
+                created = LocalDateTime.now().minusMinutes(30)
+            )
+        )
+        val uuid = dao.generateUid("Z888888")
+        assertNotNull(uuid)
+        assertEquals(testuuid.toString(), uuid.toString())
+    }
+
+    @Test
+    internal fun `should delete uuid after 4 hours`() = runBlocking {
+        val tablerow = UuidDAO.TableRow(owner = "Z888888", uuid = testuuid, created = LocalDateTime.now())
+        insert(tablerow.copy(uuid = UUID.randomUUID(), created = LocalDateTime.now().minusMinutes(120)))
+        insert(tablerow.copy(uuid = UUID.randomUUID(), created = LocalDateTime.now().minusMinutes(230)))
+        insert(tablerow.copy(uuid = UUID.randomUUID(), created = LocalDateTime.now().minusMinutes(250)))
+        insert(tablerow.copy(uuid = UUID.randomUUID(), created = LocalDateTime.now().minusMinutes(360)))
+
+        val deletedRows = dao.deleteExpired()
+        assertEquals(2, deletedRows)
+    }
+
+    suspend fun insert(row: UuidDAO.TableRow) {
+        transactional(dataSource()) { tx ->
+            tx.run(
+                queryOf("DELETE FROM owneruuid WHERE uuid = ?::uuid", row.uuid).asExecute
+            )
+            tx.run(
+                queryOf(
+                    "INSERT INTO owneruuid (owner, uuid, created) VALUES (?, ?, ?)",
+                    row.owner,
+                    row.uuid,
+                    row.created
+                ).asUpdate
+            )
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/modiapersonoversikt/infrastructure/HttpServerTest.kt
+++ b/src/test/kotlin/no/nav/modiapersonoversikt/infrastructure/HttpServerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.modiapersonoversikt.infrastructure
 
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import no.nav.modiapersonoversikt.WithDatabase
@@ -11,11 +12,20 @@ class HttpServerTest : WithDatabase {
     @Test
     fun `nais-app should have isAlive, isReady, metrics`() {
         withTestApp(connectionUrl()) {
+            val client = createClient {
+                install(HttpRequestRetry)
+            }
             val isAlive = client.get("/modiapersonoversikt-draft/internal/isAlive")
             assertEquals(isAlive.status.value, 200)
             assertEquals(isAlive.bodyAsText(), "Alive")
 
-            val isReady = client.get("/modiapersonoversikt-draft/internal/isReady")
+            val isReady = client.get("/modiapersonoversikt-draft/internal/isReady") {
+                // Use retries in case selftest-probes hasn't been run yet
+                retry {
+                    retryOnServerErrors(3)
+                }
+            }
+
             assertEquals(isReady.status.value, 200)
             assertEquals(isReady.bodyAsText(), "Ready")
 


### PR DESCRIPTION
ved en overgang til obo-tokens mellom apper må kall gjennom en frontend-proxy. Draft-appen kan motta veldig mange kall da vi automatisk synker data hit når folk skriver en melding. For å unngå at alle disse kallene må gjennom frontend-proxy legges det til en måte å oppdatere tekstene via websockets.
