### PR TITLE
[KAIZEN-0] håndterer authentisering utenom ktor

### DIFF
--- a/src/main/kotlin/no/nav/modiapersonoversikt/Application.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/Application.kt
@@ -17,7 +17,6 @@ import no.nav.modiapersonoversikt.config.Configuration
 import no.nav.modiapersonoversikt.draft.DraftDAOImpl
 import no.nav.modiapersonoversikt.draft.UuidDAOImpl
 import no.nav.modiapersonoversikt.draft.draftRoutes
-import no.nav.modiapersonoversikt.infrastructure.UUIDPrincipal
 import no.nav.modiapersonoversikt.infrastructure.exceptionHandler
 import no.nav.modiapersonoversikt.infrastructure.notFoundHandler
 import no.nav.modiapersonoversikt.utils.JacksonUtils.objectMapper
@@ -25,7 +24,6 @@ import no.nav.personoversikt.ktor.utils.Metrics
 import no.nav.personoversikt.ktor.utils.Security
 import no.nav.personoversikt.ktor.utils.Selftest
 import org.slf4j.event.Level
-import java.util.*
 import javax.sql.DataSource
 import kotlin.concurrent.fixedRateTimer
 import kotlin.time.Duration.Companion.minutes
@@ -71,11 +69,6 @@ fun Application.draftApp(
             security.setupMock(this, "Z999999")
         } else {
             security.setupJWT(this)
-        }
-        basic("ws") {
-            validate {
-                UUIDPrincipal(UUID.fromString(it.name))
-            }
         }
     }
 

--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftRoutes.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftRoutes.kt
@@ -13,7 +13,6 @@ import io.ktor.util.pipeline.*
 import io.ktor.util.reflect.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
-import no.nav.modiapersonoversikt.infrastructure.UUIDPrincipal
 import no.nav.modiapersonoversikt.log
 import no.nav.personoversikt.ktor.utils.Security.SubjectPrincipal
 import java.util.*
@@ -57,24 +56,32 @@ fun Route.draftRoutes(authProviders: Array<String?>, dao: DraftDAO, uuidDAO: Uui
             }
         }
     }
-    authenticate("ws") {
-        webSocket("/draft/ws") {
-            val uuid = checkNotNull(this.call.principal<UUIDPrincipal>()).uuid
-            val ownerUuid: UuidDAO.OwnerUUID? = uuidDAO.getOwner(uuid)
-            if (ownerUuid == null) {
-                close(CloseReason(code = 4010, message = "Unauthorized"))
-            } else if (ownerUuid.shouldBeRefreshed) {
-                close(CloseReason(code = 4060, message = "Refresh credentials"))
-            } else {
-                try {
-                    while (true) {
-                        wsHandler.process(ownerUuid.owner, receiveDeserialized())
-                    }
-                } catch (e: ClosedReceiveChannelException) {
-                    // This is expected when client disconnectes
-                } catch (e: Throwable) {
-                    log.error("Error in WS", e)
+
+    webSocket("/draft/ws") {
+        val credentials: UserPasswordCredential? = call.request.basicAuthenticationCredentials()
+        val ownerUuid: UuidDAO.OwnerUUID? = credentials
+            ?.name
+            ?.let {
+                runCatching { UUID.fromString(it) }
+                    .onFailure { log.error("Received credentials but was invalid uuid: $it") }
+                    .getOrNull()
+            }
+            ?.let { uuidDAO.getOwner(it) }
+        if (ownerUuid == null) {
+            log.warn("Received credentials but could not find owner in db")
+            close(CloseReason(code = 4010, message = "Unauthorized"))
+        } else if (ownerUuid.shouldBeRefreshed) {
+            log.warn("Received credentials but needs refreshing")
+            close(CloseReason(code = 4060, message = "Refresh credentials"))
+        } else {
+            try {
+                while (true) {
+                    wsHandler.process(ownerUuid.owner, receiveDeserialized())
                 }
+            } catch (e: ClosedReceiveChannelException) {
+                // This is expected when client disconnectes
+            } catch (e: Throwable) {
+                log.error("Error in WS", e)
             }
         }
     }

--- a/src/main/kotlin/no/nav/modiapersonoversikt/infrastructure/UUIDPrincipal.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/infrastructure/UUIDPrincipal.kt
@@ -1,6 +1,0 @@
-package no.nav.modiapersonoversikt.infrastructure
-
-import io.ktor.server.auth.*
-import java.util.*
-
-data class UUIDPrincipal(val uuid: UUID) : Principal


### PR DESCRIPTION
slik at vi kan gi korrekte tilbakemeldinger til ws-clienter, e.g lukke ws-forbindelse ved feil istedet for 401 http-status-kode.
