### PR TITLE
[KAIZEN-0] lukke websockets når serveren stoppes

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -24,7 +24,7 @@ spec:
     path: /modiapersonoversikt-draft/internal/metrics
   resources:
     requests:
-      cpu: 50m
+      cpu: 150m
       memory: 256Mi
     limits:
       cpu: 2000m

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -24,7 +24,7 @@ spec:
     path: /modiapersonoversikt-draft/internal/metrics
   resources:
     requests:
-      cpu: 50m
+      cpu: 150m
       memory: 256Mi
     limits:
       cpu: 2000m
@@ -34,7 +34,7 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 65
+    cpuThresholdPercentage: 75
   azure:
     application:
       enabled: true

--- a/src/main/kotlin/no/nav/modiapersonoversikt/utils/SessionList.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/utils/SessionList.kt
@@ -1,0 +1,26 @@
+package no.nav.modiapersonoversikt.utils
+
+import io.ktor.websocket.*
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+class SessionList {
+    private val lock = Semaphore(permits = 1)
+    private val list = mutableListOf<WebSocketSession>()
+
+    suspend fun <T> track(session: WebSocketSession, block: suspend () -> T): T {
+        lock.withPermit { list.add(session) }
+        val res = block()
+        lock.withPermit { list.remove(session) }
+        return res
+    }
+
+    suspend fun closeAll(reason: CloseReason = CloseReason(CloseReason.Codes.NORMAL, "")) {
+        lock.withPermit {
+            list.forEach { session ->
+                session.close(reason)
+            }
+            list.clear()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/modiapersonoversikt/utils/SessionList.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/utils/SessionList.kt
@@ -3,10 +3,14 @@ package no.nav.modiapersonoversikt.utils
 import io.ktor.websocket.*
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import no.nav.personoversikt.ktor.utils.Metrics
 
 class SessionList {
     private val lock = Semaphore(permits = 1)
     private val list = mutableListOf<WebSocketSession>()
+    init {
+        Metrics.Registry.gaugeCollectionSize("ws-sessions", emptyList(), list)
+    }
 
     suspend fun <T> track(session: WebSocketSession, block: suspend () -> T): T {
         lock.withPermit { list.add(session) }


### PR DESCRIPTION
effektivt sett vil dette sende en siste melding til WS-clienten med status-kode 1001, som forteller at serveren er iferd med å forsvinne.

Dette er i motsetning til tidligere hvor `CLOSED_ABNORMALLY`/`1006` var statusen klientene oppdagen når de ikke lengre fikk kontakt.
