### PR TITLE
Endre sletting av drafts til 7 dager

### DIFF
--- a/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftDAOImpl.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/draft/DraftDAOImpl.kt
@@ -44,7 +44,7 @@ class DraftDAOImpl(private val dataSource: DataSource) : DraftDAO {
     override suspend fun deleteOldDrafts() {
         return transactional(dataSource) { tx ->
             log.info("Deleting old drafts")
-            val deletedLines = tx.run(queryOf("DELETE FROM $table WHERE created < now() - INTERVAL '4 HOUR'").asUpdate)
+            val deletedLines = tx.run(queryOf("DELETE FROM $table WHERE created < now() - INTERVAL '7 DAYS'").asUpdate)
             log.info("Deleted old drafts: $deletedLines")
         }
     }


### PR DESCRIPTION
4 timer er for lite og vi får flere saker med veiledere som savner
kladder og meldinger som de skrev tidligere eller dagen før.
